### PR TITLE
Add option to ignore pipeline stages

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   </parent>
 
   <artifactId>prometheus</artifactId>
-  <version>2.2.3-SNAPSHOT</version>
+  <version>2.2.3-1-SNAPSHOT</version>
   <packaging>hpi</packaging>
   <name>Prometheus metrics plugin</name>
   <description>Expose Jenkins metrics in prometheus format</description>

--- a/src/main/java/org/jenkinsci/plugins/prometheus/JobCollector.java
+++ b/src/main/java/org/jenkinsci/plugins/prometheus/JobCollector.java
@@ -380,6 +380,12 @@ public class JobCollector extends Collector {
 
         buildMetrics.jobBuildStartMillis.labels(buildLabelValueArray).set(millis);
 
+        boolean isCollectStageMetrics = PrometheusConfiguration.get().isCollectStageMetrics();
+
+        if (!isCollectStageMetrics) {
+            logger.debug("ignore stage metrics for run [{}] from job [{}]", run.getNumber(), job.getName());
+            return;
+        }
 
         if (!run.isBuilding()) {
             buildMetrics.jobBuildDuration.labels(buildLabelValueArray).set(duration);

--- a/src/main/java/org/jenkinsci/plugins/prometheus/config/PrometheusConfiguration.java
+++ b/src/main/java/org/jenkinsci/plugins/prometheus/config/PrometheusConfiguration.java
@@ -59,6 +59,7 @@ public class PrometheusConfiguration extends GlobalConfiguration {
 
     private boolean collectDiskUsage = true;
     private boolean collectNodeStatus = true;
+    private boolean collectStageMetrics = true;
 
 
     public PrometheusConfiguration() {
@@ -92,6 +93,7 @@ public class PrometheusConfiguration extends GlobalConfiguration {
         appendStatusLabel = json.getBoolean("appendStatusLabel");
         perBuildMetrics = json.getBoolean("perBuildMetrics");
         collectNodeStatus = json.getBoolean("collectNodeStatus");
+        collectStageMetrics = json.getBoolean("collectStageMetrics");
 
         labeledBuildParameterNames = json.getString("labeledBuildParameterNames");
 
@@ -258,6 +260,15 @@ public class PrometheusConfiguration extends GlobalConfiguration {
 
     public boolean isCollectNodeStatus() {
         return collectNodeStatus;
+    }
+
+    public boolean isCollectStageMetrics() {
+        return collectStageMetrics;
+    }
+
+    public void setCollectStageMetrics(boolean collectStageMetrics) {
+        this.collectStageMetrics = collectStageMetrics;
+        save();
     }
 
     public void setPerBuildMetrics(boolean perBuildMetrics) {

--- a/src/main/resources/org/jenkinsci/plugins/prometheus/config/PrometheusConfiguration/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/prometheus/config/PrometheusConfiguration/config.jelly
@@ -53,6 +53,9 @@
     <f:entry title="${%Collect node status}" field="collectNodeStatus">
       <f:checkbox/>
     </f:entry>
+    <f:entry title="${%Collect stage metrics}" field="collectStageMetrics">
+      <f:checkbox/>
+    </f:entry>
     <f:entry title="${%Collect metrics for each run per build [Important: read help before enabling this option]}" field="perBuildMetrics">
       <f:checkbox/>
     </f:entry>

--- a/src/test/java/org/jenkinsci/plugins/prometheus/config/PrometheusConfigurationTest.java
+++ b/src/test/java/org/jenkinsci/plugins/prometheus/config/PrometheusConfigurationTest.java
@@ -215,6 +215,7 @@ public class PrometheusConfigurationTest {
         config.accumulate("labeledBuildParameterNames", "");
         config.accumulate("collectDiskUsage", "true");
         config.accumulate("collectNodeStatus", "true");
+        config.accumulate("collectStageMetrics", "true");
         config.accumulate("perBuildMetrics", "false");
         return config;
     }


### PR DESCRIPTION
Add option `collectStageMetrics`.

Allows to disable collection and publish of Pipeline stage metrics to reduce metric count and size.
